### PR TITLE
Fix makefile(s)

### DIFF
--- a/racket/src/cs/Makefile
+++ b/racket/src/cs/Makefile
@@ -179,4 +179,4 @@ chezpart.so: chezpart.sls
 
 clean:
 	rm -f chezpart.so core.so regexp.so io.so immutable-hash.so linklet.so known-primitive.so linklet.so expander.so schemify.so
-	rm -f compiled
+	rm -rf compiled

--- a/racket/src/regexp/Makefile
+++ b/racket/src/regexp/Makefile
@@ -6,12 +6,12 @@ RACO = ../../bin/raco
 # appear in the simplified expansion:
 IGNORE = ++knot read -
 
-io-src:
+regexp-src:
 	$(RACO) make main.rkt
 	$(RACO) make ../../../pkgs/expander/bootstrap-run.rkt
-	$(MAKE) compiled/io.rktl
+	$(MAKE) compiled/regexp.rktl
 
-compiled/io.rktl:
+compiled/regexp.rktl:
 	$(RACKET) ../../../pkgs/expander/bootstrap-run.rkt -t main.rkt -c compiled/cache-src  $(IGNORE) -s -x -o compiled/regexp.rktl
 
 demo:


### PR DESCRIPTION
One of these addresses #2. The other fixes the `clean` target in `racket/src/cs/Makefile`.