### PR TITLE
Mailboxes

### DIFF
--- a/racket/src/common/queue.rkt
+++ b/racket/src/common/queue.rkt
@@ -8,6 +8,7 @@
          queue-fremove!
          queue-remove-all!
          queue-add!
+         queue-add-front!
          queue-remove-node!)
 
 (struct queue (start end) #:mutable)
@@ -63,7 +64,19 @@
     (set-queue-end! q n)]
    [else
     (set-node-next! e n)
-    (set-node-prev! n e)])
+    (set-queue-end! q n)])
+  n)
+
+(define (queue-add-front! q w)
+  (define e (queue-start q))
+  (define n (node w #f e))
+  (cond
+    [(not e)
+     (set-queue-start! q n)
+     (set-queue-end! q n)]
+    [else
+     (set-node-prev! e n)
+     (set-queue-start! q n)])
   n)
 
 (define (queue-remove-node! q n)

--- a/racket/src/cs/expander-compat.scm
+++ b/racket/src/cs/expander-compat.scm
@@ -228,8 +228,6 @@
 (define (ephemeron? x) (weak-pair? x))
 
 (define (thread-resume t) (void))
-(define (thread-send t v) t)
-(define (thread-receive) (void))
 (define (thread-receive-evt t) 'thread-receive-evt)
 (define filesystem-change-evt
   (case-lambda

--- a/racket/src/cs/expander-compat.scm
+++ b/racket/src/cs/expander-compat.scm
@@ -596,6 +596,7 @@
    ephemeron?
    make-ephemeron
    ephemeron-value
+   thread-receive-evt
    filesystem-change-evt
    filesystem-change-evt-cancel
    call-with-semaphore

--- a/racket/src/cs/expander-compat.scm
+++ b/racket/src/cs/expander-compat.scm
@@ -596,9 +596,6 @@
    ephemeron?
    make-ephemeron
    ephemeron-value
-   thread-send
-   thread-receive
-   thread-receive-evt
    filesystem-change-evt
    filesystem-change-evt-cancel
    call-with-semaphore

--- a/racket/src/cs/primitive/kernel.scm
+++ b/racket/src/cs/primitive/kernel.scm
@@ -714,6 +714,7 @@
    thread-resume
    thread-running?
    thread-send
+   thread-receive
    thread-suspend
    thread-wait
    true-object?

--- a/racket/src/thread/main.rkt
+++ b/racket/src/thread/main.rkt
@@ -32,6 +32,10 @@
          thread-dead-evt?
          break-thread
          kill-thread
+         thread-send
+         thread-receive
+         thread-try-receive
+         thread-rewind-receive
 
          sleep
          

--- a/racket/src/thread/thread.rkt
+++ b/racket/src/thread/thread.rkt
@@ -509,7 +509,7 @@
   (define head (thread-mbx-head thd))
   (cond
     [(null? head)
-     (error "NO MAIL\n")]
+     (internal-error "NO MAIL\n")]
     [(null? (mcdr head))
      (set-thread-mbx-head! thd '())
      (set-thread-mbx-tail! thd '())

--- a/racket/src/thread/thread.rkt
+++ b/racket/src/thread/thread.rkt
@@ -154,7 +154,7 @@
 ;; Thread status
 
 (define (thread-running? t)
- ;; (check 'thread-running? thread? t)
+  (check 'thread-running? thread? t)
   (and (not (eq? 'done (thread-engine t)))
        (not (thread-suspended? t))))
 


### PR DESCRIPTION
Implementation of racket thread mailboxes.  

Run time of thread-ring benchmark is around 3 minutes and is 2 seconds when run in regular racket for an n of 1000000.  Not sure yet what is causing this slowdown.

A simpler benchmark with 2 threads (1 sender, 1 receiver) sending and receiving 1000000 messages runs in about 2.25 seconds.

Edit: Calls to engine-block in thread-receive seem to be the cause of the slowdown.