### PR TITLE
implementation of processor-count

### DIFF
--- a/racket/src/cs/core/future.ss
+++ b/racket/src/cs/core/future.ss
@@ -12,19 +12,18 @@
     id))
 
 (define-record-type (future* make-future future?)
-    (fields id would-be? (mutable thunk) (mutable engine) 
+    (fields id would-be? (mutable thunk) (mutable engine)
 	    (mutable result) (mutable done?) cond lock))
 ;; future? defined by record.
 
 (define (futures-enabled?)
   (threaded?))
 
-#| Chez doesn't seem to have a built in function that does this.
-Can call out to C in chez, so maybe can just duplicate what
-racket currently does in C.
-|#
-(define (processor-count)
-  1)
+(define processor-count
+  (let ([count #f])
+    (lambda ()
+      (unless count (set! count (find-processor-count)))
+      count)))
 
 (define current-future (internal-make-thread-parameter #f))
 
@@ -43,7 +42,7 @@ racket currently does in C.
   (define (future thunk)
     (unless (scheduler-running?)
 	    (start-scheduler))
-    
+
     (let* ([f (make-future (get-next-id) #f (void) (void) (void) #f (make-condition) (make-lock #f))]
 	   [th (thunk-wrapper f thunk)])
       (future*-engine-set! f (make-engine th #f #t))
@@ -55,7 +54,7 @@ racket currently does in C.
 	   [th (thunk-wrapper f thunk)])
       (future*-thunk-set! f th)
       f))
-  
+
   (define (touch f)
     (cond
      [(future*-would-be? f)
@@ -69,7 +68,7 @@ racket currently does in C.
       (condition-wait (future*-cond f) (future*-lock f)) ;; when this returns we will have result
       (let ([result (future*-result f)])
 	(lock-release (future*-lock f))
-	result)] ;; acquired 
+	result)] ;; acquired
      [else
       (touch f)])) ;; not acquired. might be writing result now.
 
@@ -82,7 +81,7 @@ racket currently does in C.
   ]
  [else
   ;; not threaded
-  
+
   (define (thunk-wrapper f thunk)
     (lambda ()
       (let ([result (thunk)])
@@ -101,5 +100,5 @@ racket currently does in C.
   (define (touch f)
     ((future*-thunk f))
     (future*-result f))
-  
+
   ])

--- a/racket/src/cs/core/system.ss
+++ b/racket/src/cs/core/system.ss
@@ -23,3 +23,86 @@
                                  "(or/c 'os 'word 'vm 'gc 'link 'machine\n"
                                  "      'so-suffix 'so-mode 'fs-change 'cross)")
                                 mode)]))
+
+;; lifted from Chez: mats/foreign.ms
+(define-syntax machine-case
+  (lambda (x)
+    (syntax-case x ()
+      [(_ [(a ...) e ...] m ...)
+       (if (#%memq (machine-type) (datum (a ...)))
+           #'(begin (void) e ...)
+           #'(machine-case m ...))]
+      [(_ [else e ...]) #'(begin (void) e ...)]
+      [(_) #'(void)])))
+
+(define (find-processor-count)
+  (machine-case
+    [(ta6osx a6osx ti3osx i3osx)
+     ;; OS X
+     (load-shared-object "libc.dylib")
+
+     (cond
+      [(foreign-entry? "sysctlbyname")
+       (let ([fn (foreign-procedure "sysctlbyname" (string (* int) (* size_t) (* int) size_t) int)]
+             [result-out (make-ftype-pointer int (foreign-alloc (ftype-sizeof int)))]
+             [size-inout (make-ftype-pointer size_t (foreign-alloc (ftype-sizeof size_t)))]
+             [null-ptr (make-ftype-pointer int 0)])
+
+         (ftype-set! size_t () size-inout (ftype-sizeof int))
+
+         (begin0
+          (if (zero? (fn "hw.ncpu" result-out size-inout null-ptr 0))
+              (ftype-ref int () result-out)
+              1)
+
+          (foreign-free (ftype-pointer-address result-out))
+          (foreign-free (ftype-pointer-address size-inout))))]
+      [else
+       1])]
+
+    [(ta6le a6le ti3le i3le tppc32le ppc32le arm32le)
+     ;; Linux
+     (load-shared-object "libc.so.6")
+
+     (cond
+      [(foreign-entry? "sysconf")
+       (let ([fn (foreign-procedure "sysconf" (int) long)]
+             [_SC_NPROCESSORS_ONLN 84])
+         (fn _SC_NPROCESSORS_ONLN))]
+      [else
+       1])]
+
+    [(ta6nt a6nt ti3nt i3nt)
+     ;; Windows
+     (let ()
+       (define-ftype SYSTEM_INFO
+         (struct
+          [wProcessorArchitecture unsigned-16]
+          [wReserved unsigned-16]
+          [dwPageSize unsigned-32]
+          [lpMinimumApplicationAddress void*]
+          [lpMaximumApplicationAddress void*]
+          [dwActiveProcessorMask (* unsigned-32)]
+          [dwNumberOfProcessors unsigned-32]
+          [dwProcessorType unsigned-32]
+          [dwAllocationGranularity unsigned-32]
+          [wProcessorLevel unsigned-16]
+          [wProcessorRevision unsigned-16]))
+
+       (load-shared-object "crtdll.dll")
+
+       (cond
+        [(foreign-entry? "GetSystemInfo")
+         (let ([fn (foreign-procedure __stdcall "GetSystemInfo" ((* SYSTEM_INFO)) void)]
+               [info-out (make-ftype-pointer SYSTEM_INFO (foreign-alloc (ftype-sizeof SYSTEM_INFO)))])
+
+           (fn info-out)
+
+           (begin0
+            (ftype-ref SYSTEM_INFO (dwNumberOfProcessors) info-out)
+            (foreign-free (ftype-pointer-address info-out))))]
+        [else
+         1]))]
+
+    [else
+     1]))


### PR DESCRIPTION
@mflatt @spall Here's an implementation of `processor-count` that uses the Chez FFI to reproduce [the existing logic](https://github.com/racket/racket7/blob/master/racket/src/racket/src/future.c#L2178) (aside from the fact that the default is 1 instead of 2).

Two caveats:
- Obviously, this code is a lot more verbose than the corresponding C. Not sure if there's a better way to handle this.
- While I tested the OS X and Linux versions, the Windows version is untested, since I don't have a Windows development environment.

Oh, and sorry for the whitespace noise.